### PR TITLE
Use UTC timezone instead of local one

### DIFF
--- a/dbl/http.py
+++ b/dbl/http.py
@@ -216,7 +216,7 @@ class HTTPClient:
 
 async def _ratelimit_handler(until):
     """Handles the displayed message when we are ratelimited."""
-    duration = round(until - datetime.now().timestamp())
+    duration = round(until - datetime.utcnow().timestamp())
     mins = duration / 60
     fmt = "We have exhausted a ratelimit quota. Retrying in %.2f seconds (%.3f minutes)."
     log.warning(fmt, duration, mins)


### PR DESCRIPTION
Just found out that the rate limit callback uses local timezone whereas the rate limiter itself uses UTC timezone