### PR TITLE
♻️ Update grammar in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Additional information
 Examples
 --------
 
-Posting server count manually:
+Posting server count manually every 30 minutes:
 
 .. code:: py
 


### PR DESCRIPTION
I noticed in the [README](https://github.com/top-gg/python-sdk/README.rst) that in one of the examples, it was "posting server count manually" in an example of [tasks.loop](https://discordpy.readthedocs.io/en/latest/ext/tasks/index.html) to do it automatically, so I changed the grammar a bit to be in sync with what the example did.




