### PR TITLE
Fix dead link in event reference

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,7 +51,7 @@ Event reference
 
     The returned data can be found `here`_.
 
-    .. _here: https://top.gg/api/docs#webhooks
+    .. _here: https://docs.top.gg/webhooks
 
 Widgets
 -------


### PR DESCRIPTION
## Proposed Changes

  - Fixed the dead link in the event reference that lead to https://top.gg/api/docs#webhooks, which does not work.