### PR TITLE
Implement default autopost error handler and re-raise unauthorized error

### DIFF
--- a/topgg/client.py
+++ b/topgg/client.py
@@ -130,7 +130,7 @@ class DBLClient:
                 if isinstance(e, errors.Unauthorized):
                     raise
                 
-            await asyncio.sleep(1800)
+            await asyncio.sleep(self._autopost_interval)
 
     @property
     def guild_count(self) -> int:

--- a/topgg/client.py
+++ b/topgg/client.py
@@ -77,7 +77,7 @@ class DBLClient:
     autopost_task: Task
 
     def __init__(self, bot: discord.Client, token: str, autopost: bool = False, post_shard_count: bool = False,
-                 autopost_interval: int = 0, **kwargs):
+                 autopost_interval: int = 1800, **kwargs):
         self.bot = bot
         self.bot_id = None
         self.loop = bot.loop

--- a/topgg/client.py
+++ b/topgg/client.py
@@ -92,7 +92,10 @@ class DBLClient:
                 raise errors.ClientException(
                     "autopost_interval must be greater than or equal to 900 seconds (15 minutes)"
                 )
-            self.bot.on_autopost_error = self.on_autopost_error
+
+            if not hasattr(self.bot, 'on_autopost_error'):
+                self.bot.on_autopost_error = self.on_autopost_error
+
             self.autopost_task = self.loop.create_task(self._auto_post())
         else:
             if self._post_shard_count:
@@ -103,7 +106,8 @@ class DBLClient:
     async def on_autopost_error(self, exception):
         # only print if there's no external autopost_error listeners.
         if (isinstance(self.bot, BotBase)
-            and self.bot.extra_events.get("on_autopost_error")):
+            and self.bot.extra_events.get("on_autopost_error")
+        ):
             return
 
         print('Ignoring exception in auto post loop:', file=sys.stderr)


### PR DESCRIPTION
## Proposed Changes

  - Fixed docstring mismatch
  - Got rid of some Optional[bool] as they're not supposed to be None but bool only. `Optional[X] is equivalent to Union[X, None].`— [typing.Optional](https://docs.python.org/3/library/typing.html#typing.Optional)
  - Implemented a default auto-post error handler
  - Made use of `_autopost_interval` attribute
  - Made 1800 as the default value of the autopost_interval parameter
