### PR TITLE
doc(types): remove 'library' from WidgetOptions.type

### DIFF
--- a/topgg/types.py
+++ b/topgg/types.py
@@ -126,7 +126,7 @@ class WidgetOptions(DataDict[str, Any]):
     format: str
     """Format to apply to the widget. Must be either ``png`` and ``svg``. Defaults to ``png``."""
     type: str
-    """Type of a short widget (``status``, ``servers``, ``library``, ``upvotes``, and ``owner``). For large widget, 
+    """Type of a short widget (``status``, ``servers``, ``upvotes``, and ``owner``). For large widget, 
     must be an empty string."""
 
     def __init__(


### PR DESCRIPTION
`https://top.gg/api/widget/library/*` gives a 404.

## Proposed Changes
  - Removed `library` from the documentation for the `type` attribute in `WidgetOption` class definition.