### PR TITLE
Ensure client is not closed and add more client tests

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,27 @@
+import mock
+import pytest
+from aiohttp import ClientSession
+
+import topgg
+
+
+@pytest.fixture
+def session() -> ClientSession:
+    return mock.Mock(ClientSession)
+
+
+@pytest.mark.asyncio
+async def test_HTTPClient_with_external_session(session: ClientSession):
+    http = topgg.http.HTTPClient("TOKEN", session=session)
+    assert not http._own_session
+    await http.close()
+    session.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_HTTPClient_with_external_session(session: ClientSession):
+    http = topgg.http.HTTPClient("TOKEN")
+    http.session = session
+    assert http._own_session
+    await http.close()
+    session.close.assert_called_once()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,23 @@
+import typing as t
+
 import mock
 import pytest
 from aiohttp import ClientSession
 
 import topgg
+from topgg import errors
 
 
 @pytest.fixture
 def session() -> ClientSession:
     return mock.Mock(ClientSession)
+
+
+@pytest.fixture
+def client() -> topgg.DBLClient:
+    client = topgg.DBLClient(token="TOKEN", default_bot_id=1234)
+    client.http = mock.Mock(topgg.http.HTTPClient)
+    return client
 
 
 @pytest.mark.asyncio
@@ -19,9 +29,109 @@ async def test_HTTPClient_with_external_session(session: ClientSession):
 
 
 @pytest.mark.asyncio
-async def test_HTTPClient_with_external_session(session: ClientSession):
+async def test_HTTPClient_with_no_external_session(session: ClientSession):
     http = topgg.http.HTTPClient("TOKEN")
     http.session = session
     assert http._own_session
     await http.close()
     session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_bot_votes_with_no_default_bot_id():
+    client = topgg.DBLClient("TOKEN")
+    with pytest.raises(
+        errors.ClientException,
+        match="you must set default_bot_id when constructing the client.",
+    ):
+        await client.get_bot_votes()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_post_guild_count_with_no_args():
+    client = topgg.DBLClient("TOKEN", default_bot_id=1234)
+    with pytest.raises(TypeError, match="stats or guild_count must be provided."):
+        await client.post_guild_count()
+
+
+@pytest.mark.parametrize(
+    "method, kwargs",
+    [
+        (topgg.DBLClient.get_guild_count, {}),
+        (topgg.DBLClient.get_bot_info, {}),
+        (
+            topgg.DBLClient.generate_widget,
+            {
+                "options": topgg.types.WidgetOptions(),
+            },
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_DBLClient_get_guild_count_with_no_id(
+    method: t.Callable, kwargs: t.Dict[str, t.Any]
+):
+    client = topgg.DBLClient("TOKEN")
+    with pytest.raises(
+        errors.ClientException, match="bot_id or default_bot_id is unset."
+    ):
+        await method(client, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_closed_DBLClient_raises_exception():
+    client = topgg.DBLClient("TOKEN")
+    assert not client.is_closed
+    await client.close()
+    assert client.is_closed
+    with pytest.raises(errors.ClientException, match="client has been closed."):
+        await client.get_weekend_status()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_weekend_status(client: topgg.DBLClient):
+    client.http.get_weekend_status = mock.AsyncMock()
+    await client.get_weekend_status()
+    client.http.get_weekend_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_post_guild_count(client: topgg.DBLClient):
+    client.http.post_guild_count = mock.AsyncMock()
+    await client.post_guild_count(guild_count=123)
+    client.http.post_guild_count.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_guild_count(client: topgg.DBLClient):
+    client.http.get_guild_count = mock.AsyncMock(return_value={})
+    await client.get_guild_count()
+    client.http.get_guild_count.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_bot_votes(client: topgg.DBLClient):
+    client.http.get_bot_votes = mock.AsyncMock(return_value=[])
+    await client.get_bot_votes()
+    client.http.get_bot_votes.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_bots(client: topgg.DBLClient):
+    client.http.get_bots = mock.AsyncMock(return_value={"results": []})
+    await client.get_bots()
+    client.http.get_bots.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_user_info(client: topgg.DBLClient):
+    client.http.get_user_info = mock.AsyncMock(return_value={})
+    await client.get_user_info(1234)
+    client.http.get_user_info.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_DBLClient_get_user_vote(client: topgg.DBLClient):
+    client.http.get_user_vote = mock.AsyncMock(return_value={"voted": 1})
+    await client.get_user_vote(1234)
+    client.http.get_user_vote.assert_called_once()

--- a/topgg/autopost.py
+++ b/topgg/autopost.py
@@ -23,6 +23,7 @@
 __all__ = ["AutoPoster"]
 
 import asyncio
+import contextlib
 import datetime
 import sys
 import traceback
@@ -257,7 +258,8 @@ class AutoPoster:
 
     def _fut_done_callback(self, future: "asyncio.Future" = None):
         self._refresh_state()
-        future.exception()
+        with contextlib.suppress(asyncio.CancelledError):
+            future.exception()
 
     async def _internal_loop(self) -> None:
         try:

--- a/topgg/autopost.py
+++ b/topgg/autopost.py
@@ -23,7 +23,6 @@
 __all__ = ["AutoPoster"]
 
 import asyncio
-import contextlib
 import datetime
 import sys
 import traceback
@@ -258,8 +257,9 @@ class AutoPoster:
 
     def _fut_done_callback(self, future: "asyncio.Future" = None):
         self._refresh_state()
-        with contextlib.suppress(asyncio.CancelledError):
-            future.exception()
+        if future.cancelled():
+            return
+        future.exception()
 
     async def _internal_loop(self) -> None:
         try:

--- a/topgg/client.py
+++ b/topgg/client.py
@@ -74,6 +74,9 @@ class DBLClient(DataContainerMixin):
         return self._is_closed
 
     async def _ensure_session(self) -> None:
+        if self.is_closed:
+            raise errors.ClientException("client has been closed.")
+
         if not hasattr(self, "http"):
             self.http = HTTPClient(self._token, session=None)
 

--- a/topgg/client.py
+++ b/topgg/client.py
@@ -97,7 +97,7 @@ class DBLClient(DataContainerMixin):
             :obj:`bool`: The boolean value of weekend status.
 
         Raises:
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         await self._ensure_session()
@@ -149,7 +149,7 @@ class DBLClient(DataContainerMixin):
         Raises:
             TypeError
                 If no argument is provided.
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         if stats:
@@ -177,7 +177,7 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If neither bot_id or default_bot_id was set.
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         bot_id = self._validate_and_get_bot_id(bot_id)
@@ -198,7 +198,7 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If default_bot_id isn't provided when constructing the client.
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         if not self.default_bot_id:
@@ -226,7 +226,7 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If neither bot_id or default_bot_id was set.
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         bot_id = self._validate_and_get_bot_id(bot_id)
@@ -263,7 +263,7 @@ class DBLClient(DataContainerMixin):
                 Info on bots that match the search query on Top.gg.
 
         Raises:
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         sort = sort or ""
@@ -290,7 +290,7 @@ class DBLClient(DataContainerMixin):
                 Information about a Top.gg user.
 
         Raises:
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         await self._ensure_session()
@@ -310,7 +310,7 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If default_bot_id isn't provided when constructing the client.
-            :obj:`~.errors.ClientStateException
+            :obj:`~.errors.ClientStateException`
                 If the client has been closed.
         """
         if not self.default_bot_id:

--- a/topgg/client.py
+++ b/topgg/client.py
@@ -75,7 +75,7 @@ class DBLClient(DataContainerMixin):
 
     async def _ensure_session(self) -> None:
         if self.is_closed:
-            raise errors.ClientException("client has been closed.")
+            raise errors.ClientStateException("client has been closed.")
 
         if not hasattr(self, "http"):
             self.http = HTTPClient(self._token, session=None)
@@ -92,6 +92,10 @@ class DBLClient(DataContainerMixin):
 
         Returns:
             :obj:`bool`: The boolean value of weekend status.
+
+        Raises:
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         await self._ensure_session()
         data = await self.http.get_weekend_status()
@@ -142,6 +146,8 @@ class DBLClient(DataContainerMixin):
         Raises:
             TypeError
                 If no argument is provided.
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         if stats:
             guild_count = stats.guild_count
@@ -168,6 +174,8 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If neither bot_id or default_bot_id was set.
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         bot_id = self._validate_and_get_bot_id(bot_id)
         await self._ensure_session()
@@ -187,6 +195,8 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If default_bot_id isn't provided when constructing the client.
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         if not self.default_bot_id:
             raise errors.ClientException(
@@ -213,6 +223,8 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If neither bot_id or default_bot_id was set.
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         bot_id = self._validate_and_get_bot_id(bot_id)
         await self._ensure_session()
@@ -246,6 +258,10 @@ class DBLClient(DataContainerMixin):
         Returns:
             :obj:`~.types.DataDict`:
                 Info on bots that match the search query on Top.gg.
+
+        Raises:
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         sort = sort or ""
         search = search or {}
@@ -269,6 +285,10 @@ class DBLClient(DataContainerMixin):
         Returns:
             :obj:`~.types.UserData`:
                 Information about a Top.gg user.
+
+        Raises:
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         await self._ensure_session()
         response = await self.http.get_user_info(user_id)
@@ -287,6 +307,8 @@ class DBLClient(DataContainerMixin):
         Raises:
             :obj:`~.errors.ClientException`
                 If default_bot_id isn't provided when constructing the client.
+            :obj:`~.errors.ClientStateException
+                If the client has been closed.
         """
         if not self.default_bot_id:
             raise errors.ClientException(

--- a/topgg/client.py
+++ b/topgg/client.py
@@ -49,6 +49,8 @@ class DBLClient(DataContainerMixin):
             The default bot_id. You can override this by passing it when calling a method.
         session (:class:`aiohttp.ClientSession`)
             An `aiohttp session`_ to use for requests to the API.
+        **kwargs:
+            Arbitrary kwargs to be passed to :class:`aiohttp.ClientSession` if session was not provided.
     """
 
     __slots__ = ("http", "default_bot_id", "_token", "_is_closed", "_autopost")
@@ -60,6 +62,7 @@ class DBLClient(DataContainerMixin):
         *,
         default_bot_id: t.Optional[int] = None,
         session: t.Optional[aiohttp.ClientSession] = None,
+        **kwargs: t.Any,
     ) -> None:
         super().__init__()
         self._token = token

--- a/topgg/errors.py
+++ b/topgg/errors.py
@@ -25,6 +25,7 @@
 __all__ = [
     "TopGGException",
     "ClientException",
+    "ClientStateException",
     "HTTPException",
     "Unauthorized",
     "UnauthorizedDetected",
@@ -51,6 +52,10 @@ class ClientException(TopGGException):
 
     These are usually for exceptions that happened due to user input.
     """
+
+
+class ClientStateException(ClientException):
+    """Exception that's thrown when an operation happens in a closed :obj:`~.DBLClient` instance."""
 
 
 class HTTPException(TopGGException):

--- a/topgg/http.py
+++ b/topgg/http.py
@@ -52,7 +52,6 @@ async def _json_or_text(
 class HTTPClient:
     """Represents an HTTP client sending HTTP requests to the Top.gg API.
 
-    .. _event loop: https://docs.python.org/3/library/asyncio-eventloops.html
     .. _aiohttp session: https://aiohttp.readthedocs.io/en/stable/client_reference.html#client-session
 
     Args:
@@ -62,17 +61,17 @@ class HTTPClient:
     Keyword Arguments:
         session: `aiohttp session`_
             The `aiohttp session`_ used for requests to the API.
-        loop: `event loop`_
-            An `event loop`_ used for asynchronous operations.
+        **kwargs:
+            Arbitrary kwargs to be passed to :class:`aiohttp.ClientSession`.
     """
 
-    def __init__(self, token: str, **kwargs: Any) -> None:
+    def __init__(
+        self, token: str, *, session: aiohttp.ClientSession = None, **kwargs: Any
+    ) -> None:
         self.BASE = "https://top.gg/api"
         self.token = token
-        self.loop = kwargs.get("loop") or asyncio.get_event_loop()
-        session = kwargs.get("session")
         self._own_session = session is None
-        self.session = session or aiohttp.ClientSession(loop=self.loop)
+        self.session = session or aiohttp.ClientSession(**kwargs)
         self.global_rate_limiter = AsyncRateLimiter(
             max_calls=99, period=1, callback=_rate_limit_handler
         )
@@ -140,7 +139,7 @@ class HTTPClient:
                         # if is_global:
                         #     self._global_over.clear()
 
-                        await asyncio.sleep(retry_after, loop=self.loop)
+                        await asyncio.sleep(retry_after)
                         _LOGGER.debug("Done sleeping for the ratelimit. Retrying...")
 
                         # release the global lock now that the

--- a/topgg/http.py
+++ b/topgg/http.py
@@ -70,7 +70,9 @@ class HTTPClient:
         self.BASE = "https://top.gg/api"
         self.token = token
         self.loop = kwargs.get("loop") or asyncio.get_event_loop()
-        self.session = kwargs.get("session") or aiohttp.ClientSession(loop=self.loop)
+        session = kwargs.get("session")
+        self._own_session = session is None
+        self.session = session or aiohttp.ClientSession(loop=self.loop)
         self.global_rate_limiter = AsyncRateLimiter(
             max_calls=99, period=1, callback=_rate_limit_handler
         )
@@ -163,7 +165,8 @@ class HTTPClient:
         raise errors.HTTPException(resp, data)
 
     async def close(self) -> None:
-        await self.session.close()
+        if self._own_session:
+            await self.session.close()
 
     async def post_guild_count(
         self,


### PR DESCRIPTION
## Proposed Changes

  - Bugfix: suppress CancelledError exception
  - Don't close session provided by the user
  - Check if the client is closed before making any requests
      - Add `ClientStateException` error type 
  - Add more tests for better coverage
  - `DBLClient` now accepts arbitrary kwargs for instantiating a client session if not provided
